### PR TITLE
Fix debug level insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The CLM server expects logs at the `POST /log` endpoint. Both client-side (TypeS
 *   Logs are tagged with their respective `service` name ("client" or "server").
 *   Server logs are structured to provide a clean message and utilize appropriate log levels for better presentation in CLM.
 *   If CLM is unavailable or not configured, logs will fall back to the browser console (for client) or server terminal (for server). Note that very early server startup messages (before configuration is fully loaded) will also appear in the server terminal.
-*   The CLM backend now accepts "debug" level logs. Currently, the CLM UI will display "debug" logs similarly to "info" logs.
 
 ## Viewing Logs
 
@@ -65,5 +64,5 @@ Open `http://localhost:9999` in your browser to access the CLM web interface. Yo
 ## TODO
 
 - Implement an API Key system for authentication/security.
-- SQLite MCP Server for my AI coding Agent.
+- SQLite MCP Server for AI coding Agents.
 - Filtering.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ CLM runs as a Docker container.
     ```
     This will start CLM, accessible at `http://localhost:9999`. Log data is persisted in the `clm_data` directory inside your `clm` project folder.
 
+### Running locally without Docker
+
+For development purposes you can run the server directly with Python. First install the dependencies and then start the application:
+
+```bash
+pip install -r requirements.txt
+python app/main.py
+```
+
+The server listens on port `5000` and will create a `clm_data` directory for the SQLite database if it does not already exist.
+
 ## Sending Logs to CLM
 
 The CLM server expects logs at the `POST /log` endpoint. Both client-side (TypeScript) and server-side (Python) applications are configured to send logs to this endpoint.

--- a/app/database.py
+++ b/app/database.py
@@ -21,7 +21,7 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             service TEXT NOT NULL,
             timestamp INTEGER NOT NULL, -- Store as UNIX timestamp in nanoseconds (integer for perfect ordering)
-            level TEXT NOT NULL CHECK(level IN ('info', 'success', 'warning', 'error')),
+            level TEXT NOT NULL CHECK(level IN ('info', 'success', 'warning', 'error', 'debug')),
             message TEXT NOT NULL,
             details TEXT
         )


### PR DESCRIPTION
## Summary
- allow `debug` log level values in database schema
- document how to run app locally without Docker

## Testing
- `python -m py_compile app/*.py`
- `python app/main.py` *(fails: ModuleNotFoundError: No module named 'flask')*